### PR TITLE
Fix #22 - complaining about no `coordinator_context`

### DIFF
--- a/custom_components/drone_mobile/device_tracker.py
+++ b/custom_components/drone_mobile/device_tracker.py
@@ -54,3 +54,7 @@ class CarTracker(DroneMobileEntity, TrackerEntity):
     @property
     def icon(self):
         return "mdi:radar"
+
+    @property
+    def coordinator_context(self):
+        return None


### PR DESCRIPTION
Well, I haven't hacked on HomeAssistant stuff before - but these three lines of code fixed an issue I was having with the device tracker no longer reporting location data from DroneMobile.

A similar fix was made over in [hass-pfsense](https://github.com/travisghansen/hass-pfsense/commit/1c54dd443d97701f35e9567602fcb43683911525#diff-240ba9cd32b1aaefb5e05c9a4b0f88cbad92d003fa4570a245e52c5c881cd5caR553-R556) to fix some compatibility issues.

Note: I'm unsure if this resolves _all_ issues reported in #22, but at the very least it has definitely resolved the `device_tracker` GPS location issue on my HA instance.

The original error log was:
```
2022-08-06 23:59:18.915 ERROR (MainThread) [homeassistant.components.device_tracker] Error adding entities for domain device_tracker with platform drone_mobile
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 428, in async_add_entities
await asyncio.gather(*tasks)
File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 673, in _async_add_entity
await entity.add_to_platform_finish()
File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 775, in add_to_platform_finish
await self.async_added_to_hass()
File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 341, in async_added_to_hass
self._handle_coordinator_update, self.coordinator_context
AttributeError: 'CarTracker' object has no attribute 'coordinator_context'
```