### PR TITLE
Fix async_forward_entry_setups

### DIFF
--- a/custom_components/drone_mobile/__init__.py
+++ b/custom_components/drone_mobile/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.const import Platform
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -33,7 +34,12 @@ from .const import (
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
-PLATFORMS = ["lock", "sensor", "switch", "device_tracker"]
+PLATFORMS = [
+    Platform.LOCK,
+    Platform.SENSOR,
+    Platform.SWITCH,
+    Platform.DEVICE_TRACKER
+]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,8 +67,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
-    for platform in PLATFORMS:
-        await hass.config_entries.async_forward_entry_setup(entry, platform)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def async_refresh_device_status_service(self):
         await hass.async_add_executor_job(refresh_device_status, hass, coordinator)


### PR DESCRIPTION
Fix deprecated async_forward_entry_setup 

load platform const
Updated Platforms array
changed async_forward_entry_setup to async_forward_entry_setups


Fixes: [https://github.com/bjhiltbrand/drone_mobile_home_assistant/issues/44](url)