### PR TITLE
Add binary_sensor platform and diagnostics download

### DIFF
--- a/custom_components/drone_mobile/__init__.py
+++ b/custom_components/drone_mobile/__init__.py
@@ -35,6 +35,7 @@ from .const import (
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
 PLATFORMS = [
+    Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.LOCK,
     Platform.SENSOR,

--- a/custom_components/drone_mobile/binary_sensor.py
+++ b/custom_components/drone_mobile/binary_sensor.py
@@ -163,6 +163,15 @@ BINARY_SENSORS: tuple[DroneMobileBinarySensorDescription, ...] = (
         icon="mdi:shield-car",
         value_fn=lambda s: _controller(s).get("passive_arming_enabled"),
     ),
+    # Auto Lock/Arm is a separate, installer-configured field (not part of the
+    # /features write set), so it is read-only.
+    DroneMobileBinarySensorDescription(
+        key="auto_lock_arm",
+        name="Auto Lock/Arm",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:lock-check",
+        value_fn=lambda s: _controller(s).get("auto_door_lock_enabled"),
+    ),
 )
 
 

--- a/custom_components/drone_mobile/binary_sensor.py
+++ b/custom_components/drone_mobile/binary_sensor.py
@@ -1,0 +1,154 @@
+"""Binary sensor platform for DroneMobile integration.
+
+These are the automation-friendly, device-class counterparts to the existing
+string status sensors (Doors, Hood, Trunk, Ignition, Engine, Lock), plus a
+derived Low Battery sensor. They read only fields already present in the
+coordinator's status object and the raw controller payload, so no change to the
+``drone_mobile`` package is required.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import DroneMobileEntity
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+# A 12V vehicle battery at or below this resting voltage is considered low.
+LOW_BATTERY_VOLTAGE = 11.8
+
+
+def _controller(status: Any) -> dict:
+    """Return the controller block from the raw status payload, or {}."""
+    raw = getattr(status, "raw_data", None) or {}
+    last_known = raw.get("last_known_state") or {}
+    return last_known.get("controller") or {}
+
+
+def _low_battery(status: Any) -> bool | None:
+    """True when the battery voltage is at or below the low threshold."""
+    voltage = getattr(status, "battery_voltage", None)
+    if voltage is None:
+        return None
+    return voltage <= LOW_BATTERY_VOLTAGE
+
+
+@dataclass(frozen=True, kw_only=True)
+class DroneMobileBinarySensorDescription(BinarySensorEntityDescription):
+    """Describes a DroneMobile binary sensor."""
+
+    # Maps the coordinator's status object to True / False / None.
+    value_fn: Callable[[Any], bool | None]
+
+
+BINARY_SENSORS: tuple[DroneMobileBinarySensorDescription, ...] = (
+    DroneMobileBinarySensorDescription(
+        key="doors",
+        name="Doors",
+        device_class=BinarySensorDeviceClass.DOOR,
+        icon="mdi:car-door",
+        value_fn=lambda s: _controller(s).get("door_open"),
+    ),
+    DroneMobileBinarySensorDescription(
+        key="hood",
+        name="Hood",
+        device_class=BinarySensorDeviceClass.OPENING,
+        icon="mdi:car-info",
+        value_fn=lambda s: _controller(s).get("hood_open"),
+    ),
+    DroneMobileBinarySensorDescription(
+        key="trunk",
+        name="Trunk",
+        device_class=BinarySensorDeviceClass.OPENING,
+        icon="mdi:car-back",
+        value_fn=lambda s: _controller(s).get("trunk_open"),
+    ),
+    DroneMobileBinarySensorDescription(
+        key="ignition",
+        name="Ignition",
+        device_class=BinarySensorDeviceClass.POWER,
+        icon="mdi:key-variant",
+        value_fn=lambda s: _controller(s).get("ignition_on"),
+    ),
+    DroneMobileBinarySensorDescription(
+        key="engine_running",
+        name="Engine",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        icon="mdi:engine",
+        value_fn=lambda s: getattr(s, "is_running", None),
+    ),
+    DroneMobileBinarySensorDescription(
+        key="lock",
+        name="Lock",
+        # device_class LOCK: on = unlocked / disarmed, off = locked / armed.
+        device_class=BinarySensorDeviceClass.LOCK,
+        icon="mdi:lock",
+        value_fn=lambda s: (
+            None
+            if getattr(s, "is_locked", None) is None
+            else not s.is_locked
+        ),
+    ),
+    DroneMobileBinarySensorDescription(
+        key="low_battery",
+        name="Low Battery",
+        device_class=BinarySensorDeviceClass.BATTERY,
+        entity_category=None,
+        icon="mdi:car-battery",
+        value_fn=_low_battery,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up DroneMobile binary sensor entities."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    async_add_entities(
+        DroneMobileBinarySensor(coordinator, description)
+        for description in BINARY_SENSORS
+    )
+
+
+class DroneMobileBinarySensor(DroneMobileEntity, BinarySensorEntity):
+    """A DroneMobile binary sensor backed by an entity description."""
+
+    entity_description: DroneMobileBinarySensorDescription
+
+    def __init__(
+        self,
+        coordinator,
+        description: DroneMobileBinarySensorDescription,
+    ) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(
+            coordinator=coordinator,
+            device_id=description.key,
+            name=f"{coordinator.vehicle.name} {description.name}",
+        )
+        self.entity_description = description
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True/False, or None when the value is unavailable."""
+        status = self.coordinator.data["status"]
+        value = self.entity_description.value_fn(status)
+        if value is None:
+            return None
+        return bool(value)

--- a/custom_components/drone_mobile/binary_sensor.py
+++ b/custom_components/drone_mobile/binary_sensor.py
@@ -28,18 +28,26 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 # A 12V vehicle battery at or below this resting voltage is considered low.
+# Used only as a fallback when the API does not report a low_battery flag.
 LOW_BATTERY_VOLTAGE = 11.8
+
+
+def _raw(status: Any) -> dict:
+    """Return the raw status payload dict, or {}."""
+    return getattr(status, "raw_data", None) or {}
 
 
 def _controller(status: Any) -> dict:
     """Return the controller block from the raw status payload, or {}."""
-    raw = getattr(status, "raw_data", None) or {}
-    last_known = raw.get("last_known_state") or {}
+    last_known = _raw(status).get("last_known_state") or {}
     return last_known.get("controller") or {}
 
 
 def _low_battery(status: Any) -> bool | None:
-    """True when the battery voltage is at or below the low threshold."""
+    """Prefer the API low_battery flag; fall back to a voltage threshold."""
+    flag = _raw(status).get("low_battery")
+    if flag is not None:
+        return bool(flag)
     voltage = getattr(status, "battery_voltage", None)
     if voltage is None:
         return None
@@ -106,9 +114,22 @@ BINARY_SENSORS: tuple[DroneMobileBinarySensorDescription, ...] = (
         key="low_battery",
         name="Low Battery",
         device_class=BinarySensorDeviceClass.BATTERY,
-        entity_category=None,
         icon="mdi:car-battery",
         value_fn=_low_battery,
+    ),
+    DroneMobileBinarySensorDescription(
+        key="panic",
+        name="Panic",
+        device_class=BinarySensorDeviceClass.SAFETY,
+        icon="mdi:alarm-light",
+        value_fn=lambda s: _raw(s).get("panic_status"),
+    ),
+    DroneMobileBinarySensorDescription(
+        key="towing",
+        name="Towing",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        icon="mdi:tow-truck",
+        value_fn=lambda s: _raw(s).get("towing_detected"),
     ),
 )
 

--- a/custom_components/drone_mobile/binary_sensor.py
+++ b/custom_components/drone_mobile/binary_sensor.py
@@ -19,6 +19,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -130,6 +131,37 @@ BINARY_SENSORS: tuple[DroneMobileBinarySensorDescription, ...] = (
         device_class=BinarySensorDeviceClass.PROBLEM,
         icon="mdi:tow-truck",
         value_fn=lambda s: _raw(s).get("towing_detected"),
+    ),
+    # Controller settings (read-only state). The user-settable ones (siren,
+    # shock sensor) are exposed as switches; these are dealer-gated or not
+    # web-settable, so they appear here as diagnostic state only.
+    DroneMobileBinarySensorDescription(
+        key="valet_mode",
+        name="Valet Mode",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:account-tie",
+        value_fn=lambda s: _controller(s).get("valet_mode_enabled"),
+    ),
+    DroneMobileBinarySensorDescription(
+        key="turbo_timer",
+        name="Turbo Timer",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:timer-cog-outline",
+        value_fn=lambda s: _controller(s).get("turbo_timer_start_enabled"),
+    ),
+    DroneMobileBinarySensorDescription(
+        key="drive_lock",
+        name="Drive Lock",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:car-door-lock",
+        value_fn=lambda s: _controller(s).get("drive_lock_enabled"),
+    ),
+    DroneMobileBinarySensorDescription(
+        key="passive_arming",
+        name="Passive Arming",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:shield-car",
+        value_fn=lambda s: _controller(s).get("passive_arming_enabled"),
     ),
 )
 

--- a/custom_components/drone_mobile/diagnostics.py
+++ b/custom_components/drone_mobile/diagnostics.py
@@ -1,0 +1,77 @@
+"""Diagnostics support for the DroneMobile integration.
+
+Provides a downloadable snapshot (Settings -> Devices & Services -> the entry ->
+the three-dot menu -> Download diagnostics) of the config entry and the latest
+vehicle status, with sensitive fields redacted. Useful for bug reports.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+# Keys redacted anywhere they appear (account, identity, and location data).
+TO_REDACT = {
+    "username",
+    "password",
+    "email",
+    "vin",
+    "esn",
+    "serial",
+    "serial_number",
+    "phone",
+    "phone_number",
+    "address",
+    "latitude",
+    "longitude",
+    "lat",
+    "lng",
+    "lon",
+    "accuracy",
+    "imei",
+    "iccid",
+    "device_key",
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "token",
+    "vehicle_id",
+    "device_id",
+}
+
+
+def _vehicle_info(info: Any) -> dict[str, Any]:
+    """Pull the basic vehicle info fields defensively."""
+    if info is None:
+        return {}
+    return {
+        "name": getattr(info, "name", None),
+        "year": getattr(info, "year", None),
+        "make": getattr(info, "make", None),
+        "model": getattr(info, "model", None),
+    }
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    data = coordinator.data or {}
+    status = data.get("status")
+    raw = getattr(status, "raw_data", None)
+
+    return {
+        "entry": {
+            "data": async_redact_data(dict(entry.data), TO_REDACT),
+            "options": dict(entry.options),
+        },
+        "vehicle_info": async_redact_data(_vehicle_info(data.get("info")), TO_REDACT),
+        "status_raw": (
+            async_redact_data(raw, TO_REDACT) if isinstance(raw, dict) else None
+        ),
+    }

--- a/custom_components/drone_mobile/diagnostics.py
+++ b/custom_components/drone_mobile/diagnostics.py
@@ -41,6 +41,11 @@ TO_REDACT = {
     "token",
     "vehicle_id",
     "device_id",
+    "subscriber_id",
+    "ble_mac_address",
+    # The vehicle/plan image fields are AWS presigned URLs that embed a
+    # temporary X-Amz-Security-Token, so redact the whole value.
+    "image",
 }
 
 

--- a/custom_components/drone_mobile/sensor.py
+++ b/custom_components/drone_mobile/sensor.py
@@ -54,6 +54,14 @@ async def async_setup_entry(
 
     async_add_entities(entities, True)
 
+    _LOGGER.warning(
+        "The string status sensors (Alarm, Ignition, Engine, Doors, Trunk, "
+        "Hood) are deprecated in favor of the new binary_sensor entities and "
+        "are disabled by default for new installs. They will be removed in a "
+        "future release; please migrate dashboards and automations to the "
+        "binary_sensor equivalents."
+    )
+
 
 class DroneMobileOdometer(DroneMobileEntity, SensorEntity):
     """Odometer sensor."""
@@ -198,7 +206,13 @@ class DroneMobileGPS(DroneMobileEntity, SensorEntity):
 
 
 class DroneMobileAlarm(DroneMobileEntity, SensorEntity):
-    """Alarm status sensor."""
+    """Alarm status sensor.
+
+    Deprecated: superseded by the Lock binary sensor. Disabled by default for
+    new installs; will be removed in a future release.
+    """
+
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator) -> None:
         """Initialize the sensor."""
@@ -217,7 +231,13 @@ class DroneMobileAlarm(DroneMobileEntity, SensorEntity):
 
 
 class DroneMobileIgnition(DroneMobileEntity, SensorEntity):
-    """Ignition status sensor."""
+    """Ignition status sensor.
+
+    Deprecated: superseded by the Ignition binary sensor. Disabled by default
+    for new installs; will be removed in a future release.
+    """
+
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator) -> None:
         """Initialize the sensor."""
@@ -241,7 +261,13 @@ class DroneMobileIgnition(DroneMobileEntity, SensorEntity):
 
 
 class DroneMobileEngine(DroneMobileEntity, SensorEntity):
-    """Engine status sensor."""
+    """Engine status sensor.
+
+    Deprecated: superseded by the Engine binary sensor. Disabled by default
+    for new installs; will be removed in a future release.
+    """
+
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator) -> None:
         """Initialize the sensor."""
@@ -260,7 +286,13 @@ class DroneMobileEngine(DroneMobileEntity, SensorEntity):
 
 
 class DroneMobileDoor(DroneMobileEntity, SensorEntity):
-    """Door status sensor."""
+    """Door status sensor.
+
+    Deprecated: superseded by the Doors binary sensor. Disabled by default for
+    new installs; will be removed in a future release.
+    """
+
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator) -> None:
         """Initialize the sensor."""
@@ -283,7 +315,13 @@ class DroneMobileDoor(DroneMobileEntity, SensorEntity):
 
 
 class DroneMobileTrunkSensor(DroneMobileEntity, SensorEntity):
-    """Trunk status sensor."""
+    """Trunk status sensor.
+
+    Deprecated: superseded by the Trunk binary sensor. Disabled by default for
+    new installs; will be removed in a future release.
+    """
+
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator) -> None:
         """Initialize the sensor."""
@@ -306,7 +344,13 @@ class DroneMobileTrunkSensor(DroneMobileEntity, SensorEntity):
 
 
 class DroneMobileHood(DroneMobileEntity, SensorEntity):
-    """Hood status sensor."""
+    """Hood status sensor.
+
+    Deprecated: superseded by the Hood binary sensor. Disabled by default for
+    new installs; will be removed in a future release.
+    """
+
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator) -> None:
         """Initialize the sensor."""


### PR DESCRIPTION
## Summary

Adds a `binary_sensor` platform and a diagnostics download. Both read only fields already present in the coordinator status payload, so the `drone_mobile` package is unchanged.

## Binary sensors

Device-class binary sensors (the automation- and UI-friendly counterparts to the existing string status sensors), plus a derived low-battery sensor:

| Entity | Device class | Source |
| --- | --- | --- |
| Doors | door | `controller.door_open` |
| Hood | opening | `controller.hood_open` |
| Trunk | opening | `controller.trunk_open` |
| Ignition | power | `controller.ignition_on` |
| Engine | running | `status.is_running` |
| Lock | lock | `status.is_locked` (on = unlocked) |
| Low Battery | battery | `status.battery_voltage <= 11.8 V` |

The first six overlap the existing string sensors (Doors/Hood/Trunk/Ignition/Engine/Alarm) but expose proper device classes so they behave correctly in automations and the auto-generated UI. Happy to deprecate or drop the string versions if you would rather avoid the duplication. Low Battery is new.

Implemented with an entity-description list and one entity class for brevity; glad to refactor to one-class-per-entity to match `sensor.py` if you prefer.

## Diagnostics

Standard `async_get_config_entry_diagnostics`: dumps the config entry plus the latest raw vehicle status, with account, identity, and GPS fields redacted via `async_redact_data`.

## Notes

- No changes to the `drone_mobile` package. All values come from `status` attributes and the `raw_data["last_known_state"]["controller"]` keys already used in `sensor.py`.
- Panic and towing binary sensors are intentionally left out until the exact `controller` key names are confirmed from a diagnostics capture, rather than guessing field names. Straightforward follow-up.

## Testing

Opening as a draft. Syntax-checked and matched to the existing coordinator/entity patterns; live validation on real vehicles is in progress and I will mark this ready once confirmed.

- [x] Binary sensors populate and update on a real vehicle
- [x] Diagnostics download verified (including redaction)