### PR TITLE
Add Trunk and Locate buttons

### DIFF
--- a/custom_components/drone_mobile/button.py
+++ b/custom_components/drone_mobile/button.py
@@ -25,6 +25,8 @@ async def async_setup_entry(
     entities = [
         DroneMobileAux1Button(coordinator),
         DroneMobileAux2Button(coordinator),
+        DroneMobileTrunkButton(coordinator),
+        DroneMobileLocateButton(coordinator),
     ]
 
     async_add_entities(entities, True)
@@ -74,3 +76,51 @@ class DroneMobileAux2Button(DroneMobileEntity, ButtonEntity):
             _LOGGER.error("Failed to trigger Aux2: %s", err)
         except DroneMobileException as err:
             _LOGGER.error("Error triggering Aux2: %s", err)
+
+
+class DroneMobileTrunkButton(DroneMobileEntity, ButtonEntity):
+    """Trunk release button."""
+
+    def __init__(self, coordinator) -> None:
+        """Initialize the button."""
+        super().__init__(
+            coordinator=coordinator,
+            device_id="trunk_release",
+            name=f"{coordinator.vehicle.name} Trunk",
+        )
+        self._attr_icon = "mdi:car-back"
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        _LOGGER.debug("Opening trunk for %s", self.coordinator.vehicle.name)
+        try:
+            await self.hass.async_add_executor_job(self.coordinator.vehicle.trunk)
+        except CommandFailedError as err:
+            _LOGGER.error("Failed to open trunk: %s", err)
+        except DroneMobileException as err:
+            _LOGGER.error("Error opening trunk: %s", err)
+
+
+class DroneMobileLocateButton(DroneMobileEntity, ButtonEntity):
+    """Request a fresh GPS location from the vehicle."""
+
+    def __init__(self, coordinator) -> None:
+        """Initialize the button."""
+        super().__init__(
+            coordinator=coordinator,
+            device_id="locate",
+            name=f"{coordinator.vehicle.name} Locate",
+        )
+        self._attr_icon = "mdi:crosshairs-gps"
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        _LOGGER.debug("Requesting location for %s", self.coordinator.vehicle.name)
+        try:
+            await self.hass.async_add_executor_job(
+                self.coordinator.vehicle.get_location
+            )
+        except CommandFailedError as err:
+            _LOGGER.error("Failed to request location: %s", err)
+        except DroneMobileException as err:
+            _LOGGER.error("Error requesting location: %s", err)


### PR DESCRIPTION
## Summary

Adds two buttons for commands the `drone_mobile` package already implements but the integration did not expose:

- **Trunk** -> `vehicle.trunk()` (TRUNK)
- **Locate** -> `vehicle.get_location()` (LOCATION, requests a fresh GPS fix)

No package change. They reuse existing methods and follow the existing Aux 1 / Aux 2 button pattern. This rounds out app-control parity, since lock/unlock, remote start, panic, and aux are already exposed.

## Testing

Opening as a draft pending live validation on a real vehicle (these send actual commands to the car).