### PR TITLE
Persist token and remembered device under /config

### DIFF
--- a/custom_components/drone_mobile/__init__.py
+++ b/custom_components/drone_mobile/__init__.py
@@ -30,6 +30,7 @@ from .const import (
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
     MANUFACTURER,
+    token_storage_dir,
 )
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
@@ -134,7 +135,9 @@ class DroneMobileDataUpdateCoordinator(DataUpdateCoordinator):
             update_interval=update_interval,
         )
         self.vehicle_id = vehicle_id
-        self.client = DroneMobileClient(username, password)
+        self.client = DroneMobileClient(
+            username, password, token_dir=token_storage_dir(hass)
+        )
         self.vehicle = None
         self._available = True
 

--- a/custom_components/drone_mobile/config_flow.py
+++ b/custom_components/drone_mobile/config_flow.py
@@ -19,6 +19,7 @@ from .const import (
     DEFAULT_UNIT,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
+    token_storage_dir,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -330,6 +331,7 @@ async def validate_input(
     client = DroneMobileClient(
         data[CONF_USERNAME],
         data[CONF_PASSWORD],
+        token_dir=token_storage_dir(hass),
         mfa_callback=mfa_callback,
     )
 
@@ -358,7 +360,7 @@ async def get_vehicles(hass: core.HomeAssistant, username: str, password: str):
     Token is already valid at this point (validate_input succeeded), so no
     MFA callback is needed here.
     """
-    client = DroneMobileClient(username, password)
+    client = DroneMobileClient(username, password, token_dir=token_storage_dir(hass))
     try:
         vehicles = await hass.async_add_executor_job(client.get_vehicles)
         if not vehicles:

--- a/custom_components/drone_mobile/const.py
+++ b/custom_components/drone_mobile/const.py
@@ -1,8 +1,20 @@
 """Constants for the DroneMobile integration."""
+from pathlib import Path
 from typing import Final
 
 DOMAIN: Final = "drone_mobile"
 MANUFACTURER: Final = "DroneMobile"
+
+
+def token_storage_dir(hass) -> Path:
+    """Persistent token and device-remembering storage under ``/config``.
+
+    The library defaults to ``~/.config/drone_mobile`` which, on Home Assistant
+    OS, lives inside the Core container and is wiped on every Core update.
+    Storing under ``/config`` keeps the cached token and the remembered device
+    across updates, so MFA is not re-triggered after each upgrade.
+    """
+    return Path(hass.config.path(DOMAIN))
 
 # Configuration
 CONF_VEHICLE_ID: Final = "vehicle_id"


### PR DESCRIPTION
## Problem

On Home Assistant OS the `drone_mobile` library stores its cached token (and, with device remembering, the remembered `device.json`) in `~/.config/drone_mobile`, which lives **inside the Core container**. A normal restart preserves it, but a Home Assistant Core *update* rebuilds the container and wipes it, which forces a fresh MFA login after every upgrade.

## Change

Add a `token_storage_dir(hass)` helper and pass `token_dir=/config/drone_mobile` at all three `DroneMobileClient` call sites (the coordinator and both config-flow paths). `/config` is the persistent data volume, so the cached token and remembered device now survive Core updates.

## Notes

- Existing installs do one MFA login the first time after upgrading, to populate `/config/drone_mobile`, then stay hands-off.
- Pairs with the device-remembering work in bjhiltbrand/drone_mobile_python#21. This persistence change works with the current library too; the full no-MFA behaviour additionally needs that library PR released and the `manifest.json` requirement bumped to the new version.
