### PR TITLE
Require drone_mobile >= 0.4.1 for device remembering

### DIFF
--- a/custom_components/drone_mobile/manifest.json
+++ b/custom_components/drone_mobile/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/bjhiltbrand/drone_mobile_home_assistant",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bjhiltbrand/drone_mobile_home_assistant/issues",
-  "requirements": ["drone_mobile==0.4.0"],
-  "version": "2026.6.5"
+  "requirements": ["drone_mobile>=0.4.1"],
+  "version": "2026.6.6"
 }


### PR DESCRIPTION
## What

Bump the `drone_mobile` requirement from `==0.4.0` to `>=0.4.1`.

## Why

`0.4.1` adds Cognito device remembering, which stops accounts with MFA enabled from dropping offline every few hours (the refresh token expires and the fallback full login hits the MFA wall). `0.4.0` doesn't have it, so the integration needs `>=0.4.1` for the fix to reach users.

Pairs with the `/config` token persistence already merged in #57: together the remembered device is both created (`0.4.1`) and persisted across Core updates (#57).

Verified end to end on Home Assistant OS: after the cached token is gone, the integration re-authenticates via `DEVICE_SRP_AUTH` with no MFA prompt.
